### PR TITLE
Move testing from MSFT to Prod Tenant

### DIFF
--- a/env/base-cluster/aks.tf
+++ b/env/base-cluster/aks.tf
@@ -30,7 +30,7 @@ module "spark_node_pool" {
 }
 
 resource "azurerm_container_registry" "acr" {
-  name                = "${lower(local.name)}${random_id.storage.hex}"
+  name                = "sparkacr${random_id.storage.hex}"
   resource_group_name = azurerm_resource_group.rg.name
   location            = local.location
   sku                 = "Premium"
@@ -49,12 +49,12 @@ resource "azurerm_container_registry" "acr" {
 }
 
 resource "azurerm_role_assignment" "acr" {
-  scope = azurerm_container_registry.acr.id
+  scope                = azurerm_container_registry.acr.id
   role_definition_name = "acrpull"
-  principal_id = module.aks.aks_aad_object_id
+  principal_id         = module.aks.aks_aad_object_id
 
   depends_on = [
     azurerm_container_registry.acr,
-    
+
   ]
 }

--- a/env/base-cluster/main.tf
+++ b/env/base-cluster/main.tf
@@ -13,11 +13,16 @@ provider "azurerm" {
   tenant_id       = var.tenant_id
   features {}
 }
-provider "azuread" {}
+provider "azuread" {
+  subscription_id = var.sub
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  tenant_id       = var.tenant_id
+}
 provider "random" {}
 
 locals {
-  name                  = "sparkOnAks"
+  name                  = terraform.workspace == "Default" ? "sparkOnAks" : "${terraform.workspace}-sparkOnAks"
   location              = "westus2"
   vnet_address_space    = ["10.10.0.0/16"]
   spark_aks_pool_size   = terraform.workspace == "Default" ? 30 : 3

--- a/env/base-cluster/storage.tf
+++ b/env/base-cluster/storage.tf
@@ -5,13 +5,13 @@ resource "random_id" "storage" {
   keepers = {
     storage_id = local.name
   }
-  byte_length = 4
+  byte_length = 2
 }
 
 module "adls_gen2" {
   source = "../modules/storage-account"
 
-  name                     = "${lower(local.name)}${random_id.storage.hex}"
+  name                     = "sparkonaks${random_id.storage.hex}"
   location                 = local.location
   resource_group_name      = azurerm_resource_group.rg.name
   account_tier             = "Standard"
@@ -24,7 +24,7 @@ module "adls_gen2" {
 module "job_storage" {
   source = "../modules/storage-account"
 
-  name                     = "${lower(local.name)}jobs${random_id.storage.hex}"
+  name                     = "sparkjobs${random_id.storage.hex}"
   location                 = local.location
   resource_group_name      = azurerm_resource_group.rg.name
   account_tier             = "Standard"


### PR DESCRIPTION
This PR is meant to resolve #20 

The main resolution was handled by AAD Graph permissions for the Service Principal used to deploy the code in the GitHub Pipeline. Tests locally were done in the MSFT tenant and the azuread provider was using the Azure CLI login that would allow it to deploy. When moving to the SP for deployment in the pipeline the bug was introduced. 

The Service Principal was given the `Application.ReadWrite.All` and `Directory.ReadWrite.All` permissions in the "Azure Active Directry Graph" referenced in [Method 2: API access with admin consent](https://www.terraform.io/docs/providers/azuread/guides/service_principal_configuration.htmlhttps://www.terraform.io/docs/providers/azuread/guides/service_principal_configuration.html) in the provide docs.

closes #20