### PR TITLE
Change JDK version in Docker Image

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 # Base Image
-FROM openjdk:9-jre-slim
+FROM openjdk:8-jre-slim
 
 # Define Spark and Hadoop Verson
 ENV HADOOP_VERSION 3.2.0


### PR DESCRIPTION
* Downgrade JDK image from 9 to 8 due to Scala 2.12 support that is
pre-built with Spark.

closes #31 