### PR TITLE
Move to single node pool

### DIFF
--- a/env/base-cluster/aks.tf
+++ b/env/base-cluster/aks.tf
@@ -7,25 +7,10 @@ module "aks" {
   name                = local.name
   location            = local.location
   resource_group_name = azurerm_resource_group.rg.name
-  vm_size             = "Standard_D4s_v3"
+  vm_size             = local.spark_cluster_vm_size
   log_analytics_id    = module.log_analytics.id
   vnet_subnet_id      = module.aks_subnet.id
-
-  tags = local.tags
-}
-
-module "spark_node_pool" {
-  source = "../modules/aks-node-pool"
-
-  name           = "spark"
-  aks_cluster_id = module.aks.id
-  vm_size        = local.spark_cluster_vm_size
-  node_count     = local.spark_aks_pool_size
-  vnet_subnet_id = module.aks_subnet.id
-  node_labels = {
-    "app" : "spark",
-  }
-
+  node_count = local.spark_aks_pool_size
   tags = local.tags
 }
 

--- a/env/base-cluster/main.tf
+++ b/env/base-cluster/main.tf
@@ -16,7 +16,6 @@ provider "azurerm" {
   features {}
 }
 provider "azuread" {
-  subscription_id = var.sub
   client_id       = var.client_id
   client_secret   = var.client_secret
   tenant_id       = var.tenant_id
@@ -24,10 +23,10 @@ provider "azuread" {
 provider "random" {}
 
 locals {
-  name                  = terraform.workspace == "Default" ? "sparkOnAks" : "${terraform.workspace}-sparkOnAks"
+  name                  = terraform.workspace == "default" ? "sparkOnAks" : "${terraform.workspace}-sparkOnAks"
   location              = "westus2"
   vnet_address_space    = ["10.10.0.0/16"]
-  spark_aks_pool_size   = terraform.workspace == "Default" ? 30 : 3
+  spark_aks_pool_size   = terraform.workspace == "default" ? 30 : 3
   spark_cluster_vm_size = "Standard_E16s_v3"
   admin_username        = "azureuser"
 

--- a/env/modules/aks/variables.tf
+++ b/env/modules/aks/variables.tf
@@ -13,6 +13,9 @@ variable "resource_group_name" {
 variable "vm_size" {
   type = string
 }
+variable "node_count" {
+  type = number
+}
 variable "log_analytics_id" {
   type = string
 }


### PR DESCRIPTION
This PR will remove the Spark specific node pool and move to a single default nodepool.

**NOTE** This will be a destructive change and the cluster will need to be rebuilt. This will also mean that the ACR names will change.

closes #57 