### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,9 +83,9 @@ jobs:
       - name: Set Variable
         id: vars
         run: |
-          echo ::set-output name=AKS::$(cat drop/aks_name.txt)
-          echo ::set-output name=AKS_RG::$(cat drop/rg_name.txt)
-          echo ::set-output name=ACR::$(cat drop/acr_name.txt)
+          echo AKS=$(cat drop/aks_name.txt) >> "$GITHUB_OUTPUT"
+          echo AKS_RG=$(cat drop/rg_name.txt) >> "$GITHUB_OUTPUT"
+          echo ACR=$(cat drop/acr_name.txt) >> "$GITHUB_OUTPUT"
 
 
       # Set the target AKS cluster.

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -146,9 +146,9 @@ jobs:
       - name: Set Variable
         id: vars
         run: |
-          echo ::set-output name=AKS::$(cat drop/aks_name.txt)
-          echo ::set-output name=AKS_RG::$(cat drop/rg_name.txt)
-          echo ::set-output name=ACR::$(cat drop/acr_name.txt)
+          echo AKS=$(cat drop/aks_name.txt) >> "$GITHUB_OUTPUT"
+          echo AKS_RG=$(cat drop/rg_name.txt) >> "$GITHUB_OUTPUT"
+          echo ACR=$(cat drop/acr_name.txt) >> "$GITHUB_OUTPUT"
 
 
       # Set the target AKS cluster.

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Set Variable
         id: vars
         run: |
-          echo ::set-output name=AKS::$(cat drop/aks_name.txt)
-          echo ::set-output name=AKS_RG::$(cat drop/rg_name.txt)
-          echo ::set-output name=ACR::$(cat drop/acr_name.txt)
+          echo AKS=$(cat drop/aks_name.txt) >> "$GITHUB_OUTPUT"
+          echo AKS_RG=$(cat drop/rg_name.txt) >> "$GITHUB_OUTPUT"
+          echo ACR=$(cat drop/acr_name.txt) >> "$GITHUB_OUTPUT"
 
 
       # Set the target AKS cluster.


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter